### PR TITLE
restore Mars and outer planets

### DIFF
--- a/AstroView2/AstroView2/Base.lproj/Main.storyboard
+++ b/AstroView2/AstroView2/Base.lproj/Main.storyboard
@@ -647,6 +647,30 @@
                                                 <action selector="handleViewMars:" target="Ady-hI-5gd" id="q4T-0C-8v2"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Jupiter" id="Jnw-Ey-9zi">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="handleViewJupiter:" target="Ady-hI-5gd" id="jzi-CH-dvP"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Saturn" id="XL3-cS-fbu">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="handleViewSaturn:" target="Ady-hI-5gd" id="HsD-J7-NOf"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Uranus" id="Fyz-Zq-9ie">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="handleViewUranus:" target="Ady-hI-5gd" id="xei-IK-qjW"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Neptune" id="0VB-X4-PMc">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="handleViewNeptune:" target="Ady-hI-5gd" id="0nq-OP-XR5"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="cmk-QS-mBq"/>
                                         <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>

--- a/AstroView2/AstroView2/GameViewController.swift
+++ b/AstroView2/AstroView2/GameViewController.swift
@@ -76,8 +76,8 @@ class GameViewController: NSViewController {
         scene.rootNode.addChildNode(cameraNode)
         
         // place the camera
-        cameraNode.position = SCNVector3(x: 0, y: 0, z: 1.1 * AstroConstants.oneAu)
-        cameraNode.camera?.zFar = 5 * AstroConstants.oneAu
+        cameraNode.position = SCNVector3(x: 0, y: 0, z: 0.4 * AstroConstants.oneAu)
+        cameraNode.camera?.zFar = 60 * AstroConstants.oneAu
         
         // create and add a light to the scene
         let lightNode = SCNNode()
@@ -172,6 +172,22 @@ class GameViewController: NSViewController {
         viewByName(bodyName: "Mars")
     }
     
+    @IBAction func handleViewJupiter(_ sender: Any) {
+        viewByName(bodyName: "Jupiter")
+    }
+    
+    @IBAction func handleViewSaturn(_ sender: Any) {
+        viewByName(bodyName: "Saturn")
+    }
+    
+    @IBAction func handleViewUranus(_ sender: Any) {
+        viewByName(bodyName: "Uranus")
+    }
+    
+    @IBAction func handleViewNeptune(_ sender: Any) {
+        viewByName(bodyName: "Neptune")
+    }
+    
     @IBAction func handleViewSun(_ sender: Any) {
         // the sun is obviously at distance 0 from the center
         // of the system, so viewByName won't work
@@ -185,7 +201,6 @@ class GameViewController: NSViewController {
         
         // we'll view from .02 AU away
         let bodyMax = bodyBounds.max
-        let bodyMaxLen = bodyMax.length()
         let extensionLen = 0.01 * AstroConstants.oneAu
         let newPos = bodyMax.extendBy(by: extensionLen) + sunNode.worldPosition
         
@@ -215,7 +230,7 @@ class GameViewController: NSViewController {
         let cameraNode = scnView.pointOfView!
         let camera = cameraNode.camera!
         camera.zNear = 0.005 * AstroConstants.oneAu
-        camera.zFar = 1.5 * AstroConstants.oneAu
+        camera.zFar = 60 * AstroConstants.oneAu
         
         let oldPos = cameraNode.position
         let geometryNode = bodyNode.childNode(withName: "solarBody", recursively: true)!

--- a/AstroView2/Physics/SpiceSystemModel.swift
+++ b/AstroView2/Physics/SpiceSystemModel.swift
@@ -53,13 +53,11 @@ public class SpiceSystemModel : SystemModel {
             BodyRecord(name: "Mercury", path: ":Sun:", earthRadiusFraction: 0.3829, texturePath: "Solarsystemscope_texture_8k_mercury", orbitalPeriodEarthYears: 0.2408467),
             BodyRecord(name: "Venus", path: ":Sun:", earthRadiusFraction: 0.3829, texturePath: "2k_venus_surface", orbitalPeriodEarthYears: 0.61519726),
             BodyRecord(name: "Earth", path: ":Sun:", earthRadiusFraction: 1, texturePath: "Solarsystemscope_texture_8k_earth_daymap", orbitalPeriodEarthYears: 1.0000174),
-            /*
-            BodyRecord(name: "Mars", path: ":Sun:", earthRadiusFraction: 0.533, texturePath: "2k_mars"),
-            BodyRecord(name: "Jupiter", path: ":Sun:", earthRadiusFraction: 11.21, texturePath: "2k_jupiter"),
-            BodyRecord(name: "Saturn", path: ":Sun:", earthRadiusFraction: 9.45, texturePath: "2k_saturn"),
-            BodyRecord(name: "Uranus", path: ":Sun:", earthRadiusFraction: 4.01, texturePath: "2k_uranus"),
-            BodyRecord(name: "Neptune", path: ":Sun:", earthRadiusFraction: 3.88, texturePath: "2k_neptune"),
-            */
+            BodyRecord(name: "Mars", path: ":Sun:", earthRadiusFraction: 0.533, texturePath: "2k_mars", orbitalPeriodEarthYears: 1.8808476),
+            BodyRecord(name: "Jupiter", path: ":Sun:", earthRadiusFraction: 11.21, texturePath: "2k_jupiter", orbitalPeriodEarthYears: 11.862615),
+            BodyRecord(name: "Saturn", path: ":Sun:", earthRadiusFraction: 9.45, texturePath: "2k_saturn", orbitalPeriodEarthYears: 29.447498),
+            BodyRecord(name: "Uranus", path: ":Sun:", earthRadiusFraction: 4.01, texturePath: "2k_uranus", orbitalPeriodEarthYears: 84.016846),
+            BodyRecord(name: "Neptune", path: ":Sun:", earthRadiusFraction: 3.88, texturePath: "2k_neptune", orbitalPeriodEarthYears: 164.79132),
         ]
         
         return records


### PR DESCRIPTION
- set camera zNear/zFar better
- restore outer planet body records
  - this change relies on the use of the planets' barycenter IDs in [space-pack PR8](https://github.com/jdtx-public/space-pack/pull/8)
- add and connect menu items for viewing outer planets